### PR TITLE
Use maturin to build Python wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Build wheel
       run: |
-        pip install maturin
+        pip3 install maturin
         maturin build --release --strip
 
     - name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,14 @@ jobs:
 
     - name: Run tests
       run: cargo test
+
+    - name: Build wheel
+      run: |
+        pip install maturin
+        maturin build --release --strip
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: target/wheels/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "stamper"
+version = "0.2.0"
+description = "Find the maximum mtime in a directory."
+
+[build-system]
+requires = ["maturin>=0.14,<0.15"]
+build-backend = "maturin"
+
+[tool.maturin]
+bindings = "bin"


### PR DESCRIPTION
This is a weird but convenient way to distribute binaries.